### PR TITLE
Fix incorrect write retry in i_doomdev.c

### DIFF
--- a/src/i_doomdev.c
+++ b/src/i_doomdev.c
@@ -110,7 +110,7 @@ void I_DoomDevFlushBatch(void)
     ssize_t res = write(doom_fd, batch_cmds + done, sizeof *batch_cmds * (batch_size - done));
     if (res <= 0)
       I_Error("doomdev2 render fail");
-    done += res;
+    done += res / sizeof *batch_cmds;
   }
   done = 0;
   if (batch_size_bot)
@@ -119,7 +119,7 @@ void I_DoomDevFlushBatch(void)
     ssize_t res = write(doom_fd, batch_cmds_bot + done, sizeof *batch_cmds_bot * (batch_size_bot - done));
     if (res <= 0)
       I_Error("doomdev2 render fail");
-    done += res;
+    done += res / sizeof *batch_cmds;
   }
   batch_size = 0;
   batch_size_bot = 0;


### PR DESCRIPTION
The doomdev specification says write() should return the total size
of the commands that were processed successfuly, not the number
of commands.

However, I_DoomDevFlushBatch uses the `done` variable as a number
of commands processed, not their size. Therefore, when adding
the result of write to done, it should first divite it by the
size of a single command, to obtain the number of commands
processed by write.